### PR TITLE
Add dash mode

### DIFF
--- a/config.go
+++ b/config.go
@@ -8,6 +8,8 @@ const (
 	FIXED PtrGenerationMode = iota
 	PREPEND_LEFT_TO_RIGHT
 	PREPEND_RIGHT_TO_LEFT
+	PREPEND_LEFT_TO_RIGHT_DASH
+	PREPEND_RIGHT_TO_LEFT_DASH
 )
 
 type IPv6NotationMode int

--- a/config_parser.go
+++ b/config_parser.go
@@ -123,6 +123,10 @@ func fixConfig() {
 			currentConfig.PtrGenerationMode = PREPEND_LEFT_TO_RIGHT
 		case "prefix_rtl":
 			currentConfig.PtrGenerationMode = PREPEND_RIGHT_TO_LEFT
+		case "prefix_ltr_dash":
+			currentConfig.PtrGenerationMode = PREPEND_LEFT_TO_RIGHT_DASH
+		case "prefix_rtl_dash":
+			currentConfig.PtrGenerationMode = PREPEND_RIGHT_TO_LEFT_DASH
 		default:
 			log.Fatalf("Unknown mode \"%s\"", *currentConfig.PtrGenerationModeString)
 		}

--- a/dns_handler_ptr.go
+++ b/dns_handler_ptr.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/miekg/dns"
 	"log"
 	"net"
 	"strings"
+
+	"github.com/miekg/dns"
 )
 
 func handlePTR(this *handler, r, msg *dns.Msg) {
@@ -72,6 +73,14 @@ func handlePTR(this *handler, r, msg *dns.Msg) {
 			case PREPEND_RIGHT_TO_LEFT:
 				p.WriteString(IPToArpaDomain(ipaddr, true, netBlock.IPv6NotationMode))
 				p.WriteString(".")
+				p.WriteString(*netBlock.Domain)
+			case PREPEND_LEFT_TO_RIGHT_DASH:
+				p.WriteString(IPToArpaDomain(ipaddr, false, netBlock.IPv6NotationMode))
+				p.WriteString("-")
+				p.WriteString(*netBlock.Domain)
+			case PREPEND_RIGHT_TO_LEFT_DASH:
+				p.WriteString(IPToArpaDomain(ipaddr, true, netBlock.IPv6NotationMode))
+				p.WriteString("-")
 				p.WriteString(*netBlock.Domain)
 			default:
 				return

--- a/dns_handler_ptr.go
+++ b/dns_handler_ptr.go
@@ -75,12 +75,14 @@ func handlePTR(this *handler, r, msg *dns.Msg) {
 				p.WriteString(".")
 				p.WriteString(*netBlock.Domain)
 			case PREPEND_LEFT_TO_RIGHT_DASH:
-				p.WriteString(IPToArpaDomain(ipaddr, false, netBlock.IPv6NotationMode))
-				p.WriteString("-")
+				IPGenerate := (IPToArpaDomain(ipaddr, false, netBlock.IPv6NotationMode))
+				p.WriteString(strings.Replace(IPGenerate, ".", "-", -1))
+				p.WriteString(".")
 				p.WriteString(*netBlock.Domain)
 			case PREPEND_RIGHT_TO_LEFT_DASH:
-				p.WriteString(IPToArpaDomain(ipaddr, true, netBlock.IPv6NotationMode))
-				p.WriteString("-")
+				IPGenerate := (IPToArpaDomain(ipaddr, true, netBlock.IPv6NotationMode))
+				p.WriteString(strings.Replace(IPGenerate, ".", "-", -1))
+				p.WriteString(".")
 				p.WriteString(*netBlock.Domain)
 			default:
 				return


### PR DESCRIPTION
Add two mode, replace "." to "-", and because of IPToArpaDomain() function only support net.IP, so replace "." to "-" as the string.

PREPEND_LEFT_TO_RIGHT_DASH
PREPEND_RIGHT_TO_LEFT_DASH

# Demo: 
<img width="1172" alt="Screen Shot 2021-02-23 at 9 41 27 PM" src="https://user-images.githubusercontent.com/43361940/108851874-e439f780-761f-11eb-84aa-516339f3fea9.png">

<img width="915" alt="Screen Shot 2021-02-23 at 9 41 39 PM" src="https://user-images.githubusercontent.com/43361940/108851891-ea2fd880-761f-11eb-8958-aa0e8ec0e1e7.png">

Thank You
