### PR TITLE
add host block mapping support

### DIFF
--- a/config.go
+++ b/config.go
@@ -21,14 +21,15 @@ const (
 
 // config file
 type config struct {
-	Listen                []*string       `toml:"listen"`
-	PerNetConfigs         []*perNetConfig `toml:"net"`
-	DefaultNSes           []*string       `toml:"ns"`
-	OverrideVersionString string          `toml:"version_string"`
-	DefaultSOARecord      *SOARecord      `toml:"SOA"`
-	DefaultTTL            uint32          `toml:"default_ttl"`
-	CompressDNSMessages   bool            `toml:"compress_dns_messages"`
-	AllowVersionReporting bool            `toml:"allow_version_reporting"`
+	Listen                []*string         `toml:"listen"`
+	PerNetConfigs         []*perNetConfig   `toml:"net"`
+	PerHostConfigs        map[string]string `toml:"host"`
+	DefaultNSes           []*string         `toml:"ns"`
+	OverrideVersionString string            `toml:"version_string"`
+	DefaultSOARecord      *SOARecord        `toml:"SOA"`
+	DefaultTTL            uint32            `toml:"default_ttl"`
+	CompressDNSMessages   bool              `toml:"compress_dns_messages"`
+	AllowVersionReporting bool              `toml:"allow_version_reporting"`
 }
 
 type SOARecord struct {


### PR DESCRIPTION
make following in shorthand

```toml
[[net]]
net = "10.10.10.10/32"
mode = "fixed"
domain = "internal10.domain"

[[net]]
net = "10.10.10.20/32"
mode = "fixed"
domain = "internal20.domain"
```

to

```toml
[host]
"10.10.10.10" = "internal10.domain"
"10.10.10.20" = "internal20.domain"
```

that is inject net during startup to make sense for single host mapping